### PR TITLE
Send submit character in separate write to simulate human input

### DIFF
--- a/huhtest.go
+++ b/huhtest.go
@@ -336,10 +336,15 @@ func (r *Responder) Start(t testingi.T, timeout time.Duration) (*io.PipeReader, 
 					t.Error(err)
 				}
 
-				answer += response.submitCharacter()
-
 				log("Replying:", readableReplacer.Replace(answer))
 				if _, err := answerInput.Write([]byte(answer)); err != nil {
+					t.Error(err)
+				}
+
+				time.Sleep(20 * time.Millisecond)
+
+				log("Sending submit character ...")
+				if _, err := answerInput.Write([]byte(response.submitCharacter())); err != nil {
 					t.Error(err)
 				}
 

--- a/huhtest.go
+++ b/huhtest.go
@@ -343,7 +343,7 @@ func (r *Responder) Start(t testingi.T, timeout time.Duration) (*io.PipeReader, 
 
 				time.Sleep(20 * time.Millisecond)
 
-				log("Sending submit character ...")
+				log("Sending submit character...")
 				if _, err := answerInput.Write([]byte(response.submitCharacter())); err != nil {
 					t.Error(err)
 				}


### PR DESCRIPTION
Based on https://dr-knz.net/bubbletea-control-inversion.html

A future iteration of this should be to individually send "keystrokes", that is, for e.g. choosing the left confirmation button in a confirm, first send the left arrow key, then the submit button. If multiple are required, do it for multiple. I think this mostly is required for control sequences, not so much text.

Refs #3