### PR TITLE
Change Start to return non-closable reader and writer

### DIFF
--- a/huhtest.go
+++ b/huhtest.go
@@ -302,7 +302,7 @@ type Closer func()
 //	defer cancel()
 //
 //	myForm.WithInput(stdIn).WithOutput(stdOut).Run()
-func (r *Responder) Start(t testingi.T, timeout time.Duration) (*io.PipeReader, *io.PipeWriter, Closer) {
+func (r *Responder) Start(t testingi.T, timeout time.Duration) (io.Reader, io.Writer, Closer) {
 	t.Helper()
 
 	r.saveResponse()

--- a/huhtest_test.go
+++ b/huhtest_test.go
@@ -18,7 +18,7 @@ import (
 // to the io.PipeWriter in order and answers are captured line-by-line from the io.PipeReader.
 //
 // Returns the captured answers
-func simulateCLI(t *testing.T, questions []string, stdout *io.PipeWriter, stdin *io.PipeReader) []string {
+func simulateCLI(t *testing.T, questions []string, stdout io.Writer, stdin io.Reader) []string {
 	t.Helper()
 
 	actualAnswers := make([]string, len(questions))


### PR DESCRIPTION
The Start method already returns a dedicated closer. We do not want the readers and writers to be closable.