### PR TITLE
Remove unnecessary dependency to go-testing-interface

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.22.4
 
 require (
 	github.com/charmbracelet/huh v0.5.1
-	github.com/mitchellh/go-testing-interface v1.14.1
 	github.com/stretchr/testify v1.9.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -38,8 +38,6 @@ github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2J
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
 github.com/mattn/go-runewidth v0.0.15 h1:UNAjwbU9l54TA3KzvqLGxwWjHmMgBUVhBiTjelZgg3U=
 github.com/mattn/go-runewidth v0.0.15/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
-github.com/mitchellh/go-testing-interface v1.14.1 h1:jrgshOhYAUVNMAJiKbEu7EqAwgJJ2JqpQmpLJOu07cU=
-github.com/mitchellh/go-testing-interface v1.14.1/go.mod h1:gfgS7OtZj6MA4U1UrDRp04twqAjfvlZyCfX3sDjEym8=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
 github.com/mitchellh/hashstructure/v2 v2.0.2/go.mod h1:MG3aRVU/N29oo/V/IhBX8GR/zz4kQkprJgF2EVszyDE=
 github.com/muesli/ansi v0.0.0-20230316100256-276c6243b2f6 h1:ZK8zHtRHOkbHy6Mmr5D264iyp3TiX5OmNcI5cIARiQI=

--- a/huhtest.go
+++ b/huhtest.go
@@ -6,8 +6,6 @@ import (
 	"slices"
 	"strings"
 	"time"
-
-	testingi "github.com/mitchellh/go-testing-interface"
 )
 
 // Reference: https://www.alanwood.net/demos/ansi.html
@@ -302,7 +300,7 @@ type Closer func()
 //	defer cancel()
 //
 //	myForm.WithInput(stdIn).WithOutput(stdOut).Run()
-func (r *Responder) Start(t testingi.T, timeout time.Duration) (*io.PipeReader, *io.PipeWriter, Closer) {
+func (r *Responder) Start(t TestingT, timeout time.Duration) (*io.PipeReader, *io.PipeWriter, Closer) {
 	t.Helper()
 
 	r.saveResponse()

--- a/huhtest_test.go
+++ b/huhtest_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	testingi "github.com/mitchellh/go-testing-interface"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -183,7 +182,7 @@ func TestResponder_Start_FailsTestIfCalledNotOnceOnOnce(t *testing.T) {
 	questions := []string{"right?", "right?"}
 	expectedAnswers := []string{"left!", "left!"}
 
-	dummyT := new(testingi.RuntimeT)
+	dummyT := new(testing.T)
 
 	// Act
 	stdin, stdout, closer := responder.Start(dummyT, defaultTimeout)
@@ -209,7 +208,7 @@ func TestResponder_Start_FailsTestIfCalledMoreThanTimes(t *testing.T) {
 	questions := []string{"right?", "right?", "right?", "right?", "right?"}
 	expectedAnswers := []string{"left!", "left!", "left!", "left!", "left!"}
 
-	dummyT := new(testingi.RuntimeT)
+	dummyT := new(testing.T)
 
 	// Act
 	stdin, stdout, closer := responder.Start(dummyT, defaultTimeout)
@@ -230,7 +229,7 @@ func TestResponder_Start_TimeoutClosesPipesAndFailsTest(t *testing.T) {
 	// Arrange
 	responder := NewResponder()
 
-	dummyT := new(testingi.RuntimeT)
+	dummyT := new(testing.T)
 
 	// Act
 	formInput, formOutput, cancel := responder.Start(dummyT, 0)


### PR DESCRIPTION
This dependency is not really worth it and has been deprecated for couple of years now. In addition, I plan to use methods that are not available in that package. It is easier to just define the interface in this package